### PR TITLE
Fix Ticket #6252 "Legend shows all active layers"

### DIFF
--- a/site/js/GlobalOptions.js.templ-4326
+++ b/site/js/GlobalOptions.js.templ-4326
@@ -206,3 +206,6 @@ var sketchSymbolizersMeasureControls = {
     fillOpacity: 0.3
   }
 };
+
+//amount of layer legends shown, set this to -1 to show all
+var legend_length = 15;

--- a/site/js/GlobalOptions.js.templ-900913
+++ b/site/js/GlobalOptions.js.templ-900913
@@ -194,3 +194,6 @@ var sketchSymbolizersMeasureControls = {
     fillOpacity: 0.3
   }
 };
+
+//amount of layer legends shown, set this to -1 to show all
+var legend_length = 15;


### PR DESCRIPTION
New functions in WebgisInit.js handle clicks on layer visibility and
size the legend tab according to its contents.
Tests showed that around 40 layers cannot be handled by QGIS server in a
user friendly respond time (server has to render the maps, too).
Therefore a maximum amount of layers shown in the legend can be set in
GlobalOptions.js. Variable legend_length has been added to
GloblaOptions.js.templ*.
