### PR TITLE
Configure the main map layer's options from GlobalOptions.js

### DIFF
--- a/site/js/GlobalOptions.js.templ-4326
+++ b/site/js/GlobalOptions.js.templ-4326
@@ -91,6 +91,14 @@ var MapOptions = {
   controls: []
 };
 
+// Options for the main map layer (OpenLayers.layer)
+//see http://dev.openlayers.org/releases/OpenLayers-2.10/doc/apidocs/files/OpenLayers/Layer-js.html
+var LayerOptions = {
+  buffer:0,
+  singleTile:true,
+  ratio:1,
+  transitionEffect:"resize"
+};
 
 //overview map settings - do not change variable names!
 var OverviewMapOptions = {

--- a/site/js/GlobalOptions.js.templ-900913
+++ b/site/js/GlobalOptions.js.templ-900913
@@ -92,6 +92,15 @@ var MapOptions = {
   controls: []
 };
 
+// Options for the main map layer (OpenLayers.layer)
+//see http://dev.openlayers.org/releases/OpenLayers-2.10/doc/apidocs/files/OpenLayers/Layer-js.html
+var LayerOptions = {
+  buffer:0,
+  singleTile:true,
+  ratio:1,
+  transitionEffect:"resize"
+};
+
 //overview map settings - do not change variable names!
 var OverviewMapOptions = {
   projection: new OpenLayers.Projection("EPSG:"+epsgcode),

--- a/site/js/WebgisInit.js
+++ b/site/js/WebgisInit.js
@@ -252,7 +252,7 @@ function postLoading() {
       thematicLayer = new OpenLayers.Layer.WMS(layerTree.root.firstChild.text,
         wmsURI,
         {layers:selectedLayers.reverse().join(","),format:format,dpi:screenDpi},
-        {buffer:0,singleTile:true,ratio:1,transitionEffect:"resize"}
+        LayerOptions
       ),
       //layerOptions: {styleMap: styleMapMeasureControls}, isBaseLayer: false,
       highlightLayer = new OpenLayers.Layer.Vector("attribHighLight",{isBaseLayer: false, styleMap: styleMapHighLightLayer})


### PR DESCRIPTION
comes in handy when you want to change the layer's options without changing WebgisInit.js. We add an attribution this way.
