### PR TITLE
Rearrange code for legend tab

### DIFF
--- a/site/js/GlobalOptions.js.templ-4326
+++ b/site/js/GlobalOptions.js.templ-4326
@@ -164,6 +164,13 @@ var printCapabilities={
   "layouts":[]
 };
 
+//var legend all at 
+//if legendAllAtOnceAtBegin is set to true, the legend image is loaded at project
+//load for all visible layers and whenever the visibility for a layer or group is
+//changed by the user; if set to false, it is not loaded at the begin, but only
+//if the user selects a group or layer in the layer tree
+var legendAllAtOnceAtBegin = false;
+
 // <------------ No changes should be needed below here ------------------>
 
 //new namespace for QGIS extensions
@@ -223,11 +230,4 @@ var sketchSymbolizersMeasureControls = {
   }
 };
 
-//var legend all at 
-//if legendAllAtOnceAtBegin is set to true, the legend image is loaded at project
-//load or theme switch, if set to false, it is not loaded at the begin, but only
-//if the user selects a group or layer in the layer tree
-var legendAllAtOnceAtBegin = false;
 
-//amount of layer legends shown, set this to -1 to show all
-var legend_length = 15;

--- a/site/js/GlobalOptions.js.templ-900913
+++ b/site/js/GlobalOptions.js.templ-900913
@@ -153,6 +153,13 @@ var printCapabilities={
   "layouts":[]
 };
 
+//var legend all at 
+//if legendAllAtOnceAtBegin is set to true, the legend image is loaded at project
+//load for all visible layers and whenever the visibility for a layer or group is
+//changed by the user; if set to false, it is not loaded at the begin, but only
+//if the user selects a group or layer in the layer tree
+var legendAllAtOnceAtBegin = false;
+
 // <------------ No changes should be needed below here ------------------>
 
 //new namespace for QGIS extensions
@@ -211,12 +218,3 @@ var sketchSymbolizersMeasureControls = {
     fillOpacity: 0.3
   }
 };
-
-//var legend all at 
-//if legendAllAtOnceAtBegin is set to true, the legend image is loaded at project
-//load or theme switch, if set to false, it is not loaded at the begin, but only
-//if the user selects a group or layer in the layer tree
-var legendAllAtOnceAtBegin = false;
-
-//amount of layer legends shown, set this to -1 to show all
-var legend_length = 15;


### PR DESCRIPTION
The code calling GetLegendGraphic has been tidied up and rearranged so
that only one GetLegendGraphic request is issued per visibility change
(if legendAllAtOnceAtBegin = true). The variable maxLayersInLegend is
not used any more but the legend includes all visible layers
now.
