### PR TITLE
Allow to insert decimal number in startExtent parameter 

### DIFF
--- a/site/js/GetUrlParams.js
+++ b/site/js/GetUrlParams.js
@@ -16,7 +16,7 @@ var urlParamsOK = true;
 var wmsURI; //URI with map parameter or appended map name (with URL rewriting)
 var wmsMapName; // map parameter or appended map name (with URL rewriting)
 var maxExtent; //later holds the bounding box
-var olBoundsRegexp = /^-*\d+,-*\d+,-*\d+,-*\d+$/; //regExp to check whether bounding box matches OpenLayers bounding box format
+var olBoundsRegexp = /^-*[\d\.]+,-*[\d\.]+,-*[\d\.]+,-*[\d\.]+$/; //regExp to check whether bounding box matches OpenLayers bounding box format
 var urlString = "";
 var format = "image/png"; //the default image format
 var origFormat = format; //the original default image format, format is temporarily changed


### PR DESCRIPTION
currently is not possible to pass decimal number in bounding box values.
This patch changes the RegExp in order to allow to insert dots in values of Extent parameters.
