### PR TITLE
Remove toc in help documents

### DIFF
--- a/site/help_de.html
+++ b/site/help_de.html
@@ -22,7 +22,7 @@
  <hr>
   <nav>
     <ul class="ul_help">
-    <li class="list-header">Inhalt
+    <!--<li class="list-header">Inhalt
       <ul class="ul_help">
         <li><a href="#GeneralUsage">Allgemeines</a>
           <ul class="ul_help">
@@ -41,7 +41,7 @@
         </li>
       </ul>
     </li>
-    <br>
+    <br>-->
     <li class="list-header">Einige nützliche Links
       <ul class="ul_help">
         <li><a href="http://github.com/qgis/qgis-web-client" target="_blank">Quellcode auf Github</a></li>

--- a/site/help_en.html
+++ b/site/help_en.html
@@ -23,7 +23,7 @@
  <hr>
   <nav>
     <ul class="ul_help">
-    <li class="list-header">Table of Contents
+    <!--<li class="list-header">Table of Contents
       <ul class="ul_help">
         <li><a href="#GeneralUsage">General Usage</a>
           <ul class="ul_help">
@@ -42,7 +42,7 @@
         </li>
       </ul>
     </li>
-    <br>
+    <br>-->
     <li class="list-header">Useful links
       <ul class="ul_help">
         <li><a href="http://github.com/qgis/qgis-web-client" target="_blank">Source Code at Github</a></li>


### PR DESCRIPTION
When clicking on a link in the table of contents (toc) the anchor is
added to the url in the main window. Thus reloading is not possible
anymore. Until anybody has a fix for this the toc is disabled.
