### PR TITLE
Use WMS 1.3 throughout qgis-web-client

### DIFF
--- a/site/js/GlobalOptions.js.templ-4326
+++ b/site/js/GlobalOptions.js.templ-4326
@@ -106,7 +106,7 @@ var projectTitles = {
   "helloworld": "Hello World"
 };
 
-//EPSG projection code
+//EPSG projection code of your QGIS project
 var epsgcode = 4326;
 
 // OpenLayers global options
@@ -128,7 +128,10 @@ var LayerOptions = {
   singleTile:true,
   ratio:1,
   transitionEffect:"resize",
-	projection:"EPSG:"+epsgcode
+  projection:"EPSG:"+epsgcode,
+  yx: {"EPSG:4326": true}
+  // If your projection is known to have an inverse axis order in WMS 1.3 compared to WMS 1.1 enter true for yx.
+  // For EPSG:4326 the entry is not necessary as OpenLayers knows it by default.
 };
 
 //overview map settings - do not change variable names!

--- a/site/js/GlobalOptions.js.templ-900913
+++ b/site/js/GlobalOptions.js.templ-900913
@@ -106,7 +106,7 @@ var projectTitles = {
   "helloworld": "Hello World"
 };
 
-//EPSG projection code
+//EPSG projection code of your QGIS project
 var epsgcode = 900913;
 
 // OpenLayers global options
@@ -129,7 +129,11 @@ var LayerOptions = {
   singleTile:true,
   ratio:1,
   transitionEffect:"resize",
-	projection:"EPSG:"+epsgcode
+  projection:"EPSG:"+epsgcode,
+  yx: {"EPSG:900913": false}
+  // If your projection is known to have an inverse axis order in WMS 1.3 compared to WMS 1.1 enter true for yx.
+  // For EPSG:900913 OpenLayers should know it by default but because of a bug in OL 2.12 we enter it here.
+	
 };
 
 //overview map settings - do not change variable names!

--- a/site/js/WebgisInit.js
+++ b/site/js/WebgisInit.js
@@ -288,11 +288,16 @@ function postLoading() {
 			if (key.match(/^EPSG:*/)) {
 				var bboxArray = boundingBox[key].bbox;
 				var srs = boundingBox[key].srs;
-				maxExtent = OpenLayers.Bounds.fromArray(bboxArray);
-				//reproject if layer EPSG code is different from map EPSG code
-				if (srs != MapOptions.projection.getCode()) {
-					maxExtent.transform(new OpenLayers.Projection(bbox.srs), MapOptions.projection);
-				}
+				// dummyLayer is created only to check if reverseAxisOrder is true
+				var dummyLayer = new OpenLayers.Layer.WMS("dummy",
+					wmsURI, {
+						VERSION: "1.3.0"
+					},
+					LayerOptions
+				);
+				dummyLayer.projection = new OpenLayers.Projection("EPSG:"+epsgcode);
+				var reverseAxisOrder = dummyLayer.reverseAxisOrder(); 
+				maxExtent = OpenLayers.Bounds.fromArray(bboxArray, reverseAxisOrder);
 			}
 		}
 	}
@@ -436,7 +441,8 @@ function postLoading() {
 					layers: selectedLayers.join(","),
 					opacities: layerOpacities(selectedLayers),
 					format: format,
-					dpi: screenDpi
+					dpi: screenDpi,
+					VERSION: "1.3.0"
 				},
 				LayerOptions
 			),


### PR DESCRIPTION
Fix issue with reverse axis order that some projections have in WMS 1.3
compared to WMS 1.1. The projection of the client must match the
projection of the QGIS project.
