### PR TITLE
Improve QgsSearchCombo

### DIFF
--- a/site/js/WebgisInit.js
+++ b/site/js/WebgisInit.js
@@ -698,25 +698,25 @@ function postLoading() {
 					loadingText: geonamesLoadingString[lang],
 					emptyText: geonamesEmptyString[lang]
 				});
+				var emptySearchFieldButton = new Ext.Button({
+					scale: 'medium',
+					icon: 'gis_icons/mActionUndo.png',
+					tooltipType: 'qtip',
+					tooltip: resetSearchFieldTooltipString[lang],
+					id: 'EmptySearchField'
+				});
+				emptySearchFieldButton.handler = mapToolbarHandler;
+				myTopToolbar.insert(myTopToolbar.items.length, emptySearchFieldButton);
 			} else {
 				qgisSearchCombo = new QGIS.SearchComboBox({
 					map: geoExtMap.map,
 					highlightLayerName: 'attribHighLight',
+					hasReverseAxisOrder: thematicLayer.reverseAxisOrder(),
 					width: 300,
 					searchtables: searchtables
 				});
 			}
 			myTopToolbar.insert(myTopToolbar.items.length, qgisSearchCombo);
-
-			var emptySearchFieldButton = new Ext.Button({
-				scale: 'medium',
-				icon: 'gis_icons/mActionUndo.png',
-				tooltipType: 'qtip',
-				tooltip: resetSearchFieldTooltipString[lang],
-				id: 'EmptySearchField'
-			});
-			emptySearchFieldButton.handler = mapToolbarHandler;
-			myTopToolbar.insert(myTopToolbar.items.length, emptySearchFieldButton);
 		}
 
 		myTopToolbar.doLayout();


### PR DESCRIPTION
Changes:
- [Feature] replace reset button with ExtJS Trigger to clear search
- position cursor in search field after clearing
- display clear button only if anything is there to be cleared
- ignore user pressing enter during search
- collapse result list when search string is less than minChars
- ensure use of reverseAxisOrder for boundingBox of selected search
  result
