### PR TITLE
Add media links option for attributes

### DIFF
--- a/site/js/FeatureInfoDisplay.js
+++ b/site/js/FeatureInfoDisplay.js
@@ -327,6 +327,13 @@ function parseFIResult(node) {
                                             attValue = "<a class=\"popupLink\" href=\"" + attValue + "\" target=\"_blank\">" + attValue + "</a>";
                                         }
                                     }
+                                    // add hyperlinks for URLs containing mediaurl pattern
+                                    if (mediaurl != ''){
+                                        var mediapattern = new RegExp(mediaurl,'i');
+                                        if (mediapattern.test(attValue)){
+                                            attValue = "<a href=\"/" + attValue + "\" target=\"_blank\">" + attValue + "</a>";
+                                        }
+                                    }
                                     htmlText += "<td>" + attValue + "</td></tr>";
                                     hasAttributes = true;
                                 }

--- a/site/js/GlobalOptions.js
+++ b/site/js/GlobalOptions.js
@@ -52,6 +52,8 @@ if (enableBingCommercialMaps || enableGoogleCommercialMaps) {
 	enableBGMaps = true;
 }
 
+// media base URL to match media links in layer attributes
+var mediaurl = '';
 // do not show fields in ObjectIdentification results that have null values
 var suppressEmptyValues = true;
 // hide geometry in ObjectIdentification results (should be only false if there is a good reason to do so)


### PR DESCRIPTION
Added a "mediaurl" optional variable to Globaloptions. When this is set any attribute value will be tested against it. In case the mediaurl string is found, the attribute value is rendered as an hyerlink, with "mediaurl" as the base url.
