### PR TITLE
fix project_map == null in case of url rewriting

### DIFF
--- a/site/js/GlobalOptions.js
+++ b/site/js/GlobalOptions.js
@@ -45,6 +45,11 @@ var autoActivateSearchGeometryLayer = true;
 
 // Used to dynamically determine the project.
 var project_map = Ext.urlDecode(window.location.search.substring(1)).map;
+//in case of url rewriting http://host/maps/mapname (see apache-conf/qgis-web-client.conf.tmpl) 
+if (project_map == null){
+	project_map = window.location.pathname;
+	project_map = project_map.substring(project_map.lastIndexOf("/")+1);
+}
 
 // PHP based search scripts (postgis layers only)
 //var searchBoxQueryURL = '../php/search.php?map=' + project_map;
@@ -90,6 +95,7 @@ var showFeatureInfoLayerTitle = true;
 //config for QGIS.SearchPanel
 //Number of results: FEATURE_COUNT in WMS request
 var simpleWmsSearchMaxResults = 10;
+
 
 var simpleWmsSearch = {
   title: "Search continent",
@@ -146,6 +152,7 @@ var mapSearchPanelConfigs = {
 
 // ABP: needed for helloworld if no rewrite
 mapSearchPanelConfigs[project_map] = [simpleWmsSearch, urlRewriteSearch];
+
 
 //templates to define tooltips for a layer, to be shown on hover identify. The layer fields must be wrapped inside <%%> special tags.
 //if a layers field is found with the name "tooltip" its content will have precedence over this configuration


### PR DESCRIPTION
As enabling  url rewriting : 
RewriteRule ^/maps/([^.]+)$ /qgis-web-client/site/qgiswebclient.html [PT] 
the variable project_map cannot compute. 
This is a fix. 
Regards
