### PR TITLE
Support for a different QGIS Server as standalone print server host

### DIFF
--- a/site/js/GetUrlParams.js
+++ b/site/js/GetUrlParams.js
@@ -14,6 +14,7 @@
 var urlParams = {};
 var urlParamsOK = true;
 var wmsURI; //URI with map parameter or appended map name (with URL rewriting)
+var printURI; //URI with map parameter or appended map name (with URL rewriting) for printing
 var wmsMapName; // map parameter or appended map name (with URL rewriting)
 var maxExtent; //later holds the bounding box
 var olBoundsRegexp = /^-*[\d\.]+,-*[\d\.]+,-*[\d\.]+,-*[\d\.]+$/; //regExp to check whether bounding box matches OpenLayers bounding box format
@@ -56,6 +57,7 @@ if (!norewrite) {
 		suffix = urlBaseArray[3].substr(dashpos);
 	}
 	wmsURI = serverAndCGI + suffix + "/" + map + "?";
+	wmsURI = printServer + suffix + "/" + map + "?";
 	wmsMapName = map;
 }
 if (urlArray.length > 1) {
@@ -66,6 +68,7 @@ if (urlArray.length > 1) {
 			urlParamsOK = false;
 		} else {
 			wmsURI = serverAndCGI + "?map=" + urlParams.map + "&";
+			wmsURI = printServer + "?map=" + urlParams.map + "&";
 			wmsMapName = urlParams.map;
 		}
 	}

--- a/site/js/GlobalOptions.js
+++ b/site/js/GlobalOptions.js
@@ -9,6 +9,10 @@ var helpfile = "help_en.html";
 //do not add a ? or & after the .fcgi extension
 var serverAndCGI = "/cgi-bin/qgis_mapserv.fcgi";
 
+//Optional url for print server hosted on a different server. Default: same as above.
+// var serverAndCGI = "http://otherserver/cgi-bin/qgis_mapserv.fcgi";
+var printServer = serverAndCGI;
+
 //Define whether you want to use the GetProjectSettings extension of QGIS Server
 //for more configuration options in the project.
 //Set this to false to use GetCapabilities for older QGIS Server versions (<= 1.8).

--- a/site/js/QGISExtensions.js
+++ b/site/js/QGISExtensions.js
@@ -366,7 +366,7 @@ Ext.extend(QGIS.PrintProvider, GeoExt.data.PrintProvider, {
     });
     Ext.getBody().mask(printLoadingString[lang], 'x-mask-loading');
     var protocol = new OpenLayers.Protocol.WFS({
-            url: wmsURI,
+            url: printURI,
             featureType: 'print',
             geometryName: 'geometry',
             srsName: authid,

--- a/site/js/WebgisInit.js
+++ b/site/js/WebgisInit.js
@@ -422,16 +422,16 @@ function postLoading() {
 	}
 
 	// The printProvider that connects us to the print service
-	printUri = wmsURI + 'SERVICE=WMS&VERSION=1.3&REQUEST=GetPrint&FORMAT=pdf&EXCEPTIONS=application/vnd.ogc.se_inimage&TRANSPARENT=true';
+	printUrl = printURI + 'SERVICE=WMS&VERSION=1.3&REQUEST=GetPrint&FORMAT=pdf&EXCEPTIONS=application/vnd.ogc.se_inimage&TRANSPARENT=true';
 	if (initialLoadDone) {
 		printProvider.capabilities = printCapabilities;
-		printProvider.url = printUri;
+		printProvider.url = printUrl;
 	}
 	else {
 		printProvider = new QGIS.PrintProvider({
 			method: "GET", // "POST" recommended for production use
 			capabilities: printCapabilities, // from the info.json script in the html
-			url: printUri
+			url: printUrl
 		});
         printProvider.addListener("beforeprint", customBeforePrint);
 	}


### PR DESCRIPTION
This commit adds an option called 'printServer' in GlobalOptions.js: it permits to define, if set, a different QGIS Server location that acts as a standalone print server.

The default value of that parameter is printServer == serverAndCGI, if not modified it acts as before.
