### PR TITLE
Fix for undefined function call

### DIFF
--- a/site/js/WebgisInit.js
+++ b/site/js/WebgisInit.js
@@ -1194,7 +1194,7 @@ function postLoading() {
 			customActionLayerTreeCheck(n);
 		});
 		format = imageFormatForLayers(selectedLayers);
-		updateLayerOrderPanel();
+		updateLayerOrderPanelVisibilities();
 
 		//change array order
 		selectedLayers = layersInDrawingOrder(selectedLayers);

--- a/site/js/WebgisInit.js
+++ b/site/js/WebgisInit.js
@@ -1194,7 +1194,7 @@ function postLoading() {
 			customActionLayerTreeCheck(n);
 		});
 		format = imageFormatForLayers(selectedLayers);
-		updateLayerOrderPanelVisibilities();
+		updateLayerOrderPanel();
 
 		//change array order
 		selectedLayers = layersInDrawingOrder(selectedLayers);


### PR DESCRIPTION
I encountered an uncaught JavaScript exception from an undefined function updateLayerOrderPanel() in WebgisInit.js. The undefined function resulted in the check boxes for map layers not functioning at all. I believe the function call should be to updateLayerOrderPanelVisibilities() which seems to reinstate the intended functionality.