### PR TITLE
send content-type for jsonp requests instead of json

### DIFF
--- a/wsgi/search.wsgi
+++ b/wsgi/search.wsgi
@@ -141,7 +141,7 @@ def application(environ, start_response):
   if "cb" in request.params:
     resultString = request.params["cb"] + '(' + resultString + ')'
 
-  response = Response(resultString,"200 OK",[("Content-type","application/json"),("Content-length", str(len(resultString)) )])
+  response = Response(resultString,"200 OK",[("Content-type","application/javascript"),("Content-length", str(len(resultString)) )])
 
   conn.close()
 


### PR DESCRIPTION
prevent chrome error message
MIME type ('application/json') is not executable, and strict MIME type checking is enabled