### PR TITLE
Add NULL as a valid empty value for attributes in popups as it is the…

### DIFF
--- a/site/js/FeatureInfoDisplay.js
+++ b/site/js/FeatureInfoDisplay.js
@@ -310,7 +310,7 @@ function parseFIResult(node) {
                         if (attributeNode.nodeName == "Attribute") {
                             var attName = attributeNode.getAttribute("name");
                             var attValue = attributeNode.getAttribute("value");
-                            if ((attName !== mapInfoFieldName) && ((suppressEmptyValues == true && attValue.replace(/^\s\s*/, '').replace(/\s\s*$/, '') !== "") || suppressEmptyValues == false)) {
+                            if ((attName !== mapInfoFieldName) && (((suppressEmptyValues == true && ((attValue.replace(/^\s\s*/, '').replace(/\s\s*$/, '') !== "") && (attValue !== "NULL")))) || suppressEmptyValues == false)) {
                                 if (attName === "geometry") {
                                     var feature = new OpenLayers.Feature.Vector(OpenLayers.Geometry.fromWKT(attValue));
                                     geoms.push(feature);


### PR DESCRIPTION
… default QGIS empty value

If you install QGIS all attributes that are empty are displayed as 'NULL'. These fields should be considered empty by the web client in the Feature Popups. This patch does that.