### PR TITLE
set Google maps off by default

### DIFF
--- a/site/js/GlobalOptions.js
+++ b/site/js/GlobalOptions.js
@@ -82,7 +82,7 @@ if (enableBingCommercialMaps) {
     var bingApiKey = "add Bing api key here"; // http://msdn.microsoft.com/en-us/library/ff428642.aspx
 }
 
-var enableGoogleCommercialMaps = true;
+var enableGoogleCommercialMaps = false;
 
 var enableOSMMaps = true;
 


### PR DESCRIPTION
Just thought of setting enableGoogleCommercialMaps to false by default so that newcomers don't see any errors when using QWC by default.

This would make it easier for the audience of a [QGIS Server tutorial](https://github.com/qgis/QGIS-Documentation/pull/1388) I'm writing.
